### PR TITLE
fix: update uri references in plugin.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ trivy plugin install .
 
 ## License
 
-MIT License
+Apache License, Version 2.0

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -8,22 +8,22 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_darwin_amd64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_darwin-amd64.tar.gz
     bin: ./zarf
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_darwin_arm64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_darwin-arm64.tar.gz
     bin: ./zarf
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_linux_amd64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_linux-amd64.tar.gz
     bin: ./zarf
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_linux_arm64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_linux-arm64.tar.gz
     bin: ./zarf
 requirements:
   - name: zarf


### PR DESCRIPTION
Fixes the URIs

```sh
willswire/trivy-plugin-zarf > trivy plugin install github.com/willswire/trivy-plugin-zarf
2025-03-31T14:52:47-05:00       INFO    [plugin] Installing the plugin...       src="github.com/willswire/trivy-plugin-zarf"
2025-03-31T14:52:48-05:00       FATAL   Fatal error     plugin install error: failed to install the plugin: unable to download the execution file (https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_darwin_arm64.tar.gz): failed to download https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.1.0/trivy-plugin-zarf_0.1.0_darwin_arm64.tar.gz: bad response code: 404
```