### PR TITLE
chore: replace custom OCI types with opencontainers/image-spec library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/willswire/trivy-plugin-zarf
 
 go 1.21
+
+require github.com/opencontainers/image-spec v1.1.1
+
+require github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
+github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestFileAndDirExists(t *testing.T) {
@@ -39,9 +41,9 @@ func TestFileAndDirExists(t *testing.T) {
 	}
 }
 
-func TestGetImageName(t *testing.T) {
+func TestGetImageNameFromDescriptor(t *testing.T) {
 	// Test with org.opencontainers.image.ref.name annotation
-	manifest := Manifest{
+	descriptor := v1.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
 		Digest:    "sha256:123456789abcdef1234567",
 		Size:      1024,
@@ -50,13 +52,13 @@ func TestGetImageName(t *testing.T) {
 		},
 	}
 
-	name := getImageName(manifest)
+	name := getImageNameFromDescriptor(descriptor)
 	if name != "test-image:latest" {
-		t.Errorf("getImageName with ref.name annotation returned %s, expected test-image:latest", name)
+		t.Errorf("getImageNameFromDescriptor with ref.name annotation returned %s, expected test-image:latest", name)
 	}
 
 	// Test with org.opencontainers.image.base.name annotation (no ref.name)
-	manifest = Manifest{
+	descriptor = v1.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
 		Digest:    "sha256:123456789abcdef1234567",
 		Size:      1024,
@@ -65,13 +67,13 @@ func TestGetImageName(t *testing.T) {
 		},
 	}
 
-	name = getImageName(manifest)
+	name = getImageNameFromDescriptor(descriptor)
 	if name != "base-image:latest" {
-		t.Errorf("getImageName with base.name annotation returned %s, expected base-image:latest", name)
+		t.Errorf("getImageNameFromDescriptor with base.name annotation returned %s, expected base-image:latest", name)
 	}
 
 	// Test with both annotations (ref.name should take precedence)
-	manifest = Manifest{
+	descriptor = v1.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
 		Digest:    "sha256:123456789abcdef1234567",
 		Size:      1024,
@@ -81,34 +83,34 @@ func TestGetImageName(t *testing.T) {
 		},
 	}
 
-	name = getImageName(manifest)
+	name = getImageNameFromDescriptor(descriptor)
 	if name != "ref-name-image:latest" {
-		t.Errorf("getImageName with both annotations returned %s, expected ref-name-image:latest", name)
+		t.Errorf("getImageNameFromDescriptor with both annotations returned %s, expected ref-name-image:latest", name)
 	}
 
 	// Test without annotations but with long enough digest
-	manifest = Manifest{
+	descriptor = v1.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
 		Digest:    "sha256:123456789abcdef1234567",
 		Size:      1024,
 	}
 
-	name = getImageName(manifest)
+	name = getImageNameFromDescriptor(descriptor)
 	expectedPrefix := "123456789abcdef"
 	if len(name) < len(expectedPrefix) || name[:len(expectedPrefix)] != expectedPrefix {
-		t.Errorf("getImageName without annotations returned %s, expected to start with %s", name, expectedPrefix)
+		t.Errorf("getImageNameFromDescriptor without annotations returned %s, expected to start with %s", name, expectedPrefix)
 	}
 
 	// Test with short digest
-	manifest = Manifest{
+	descriptor = v1.Descriptor{
 		MediaType: "application/vnd.oci.image.manifest.v1+json",
 		Digest:    "short-digest",
 		Size:      1024,
 	}
 
-	name = getImageName(manifest)
+	name = getImageNameFromDescriptor(descriptor)
 	if name != "short-digest" {
-		t.Errorf("getImageName with short digest returned %s, expected short-digest", name)
+		t.Errorf("getImageNameFromDescriptor with short digest returned %s, expected short-digest", name)
 	}
 }
 


### PR DESCRIPTION
  ## Summary

  - Replaced custom OCI type definitions with standard types from opencontainers/image-spec
  - Refactored related functions to use the standard OCI types
  - Updated tests to work with the standard types

  ## Test plan

  - Run existing tests to verify they still pass
  - Test with a real Zarf package to ensure scanning still works correctly