### PR TITLE
feat: add architecture flag to support multi-arch packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ trivy zarf [flags] <zarf-package.tar> or <oci://registry/repository:tag>
 | `--help` | `-h` | Display help information |
 | `--output DIR` | `-o DIR` | Save scan results as JSON files in specified directory |
 | `--skip-signature-validation` | | Skip signature validation when pulling from OCI registry |
+| `--arch ARCHITECTURE` | `-a ARCHITECTURE` | Architecture to pull for OCI images (e.g., `amd64`, `arm64`) |
 
 ### Basic Examples
 
@@ -62,6 +63,12 @@ Skip signature validation when pulling from OCI registry:
 
 ```bash
 trivy zarf --skip-signature-validation oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0
+```
+
+Pull and scan a specific architecture from an OCI registry:
+
+```bash
+trivy zarf --arch amd64 oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0
 ```
 
 ### Output Options
@@ -88,6 +95,9 @@ trivy zarf --output ./scan-results zarf-package-dos-games-arm64-1.2.0.tar.zst
 
 # Or scan directly from OCI in one step
 trivy zarf --skip-signature-validation --output ./scan-results oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0
+
+# Pull and scan a specific architecture from OCI in one step
+trivy zarf --arch arm64 --output ./scan-results oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0
 ```
 
 ## Development
@@ -116,6 +126,9 @@ Run the plugin binary directly:
 
 # Test with output flags
 ./trivy-plugin-zarf --output ./results zarf-package-dos-games-arm64-1.2.0.tar.zst
+
+# Test with architecture specification
+./trivy-plugin-zarf --arch arm64 oci://ghcr.io/zarf-dev/packages/dos-games:1.2.0
 ```
 
 ### Linking for Development

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: zarf
 repository: github.com/willswire/trivy-plugin-zarf
-version: 0.3.0
+version: 0.3.1
 maintainer: willswire
 summary: Scan Zarf packages for vulnerabilities
 usage: zarf <zarf-package.tar> or <oci://registry/repository:tag>
@@ -9,22 +9,22 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.3.0/trivy-plugin-zarf_0.3.0_darwin-amd64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.3.1/trivy-plugin-zarf_0.3.1_darwin-amd64.tar.gz
     bin: ./zarf
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.3.0/trivy-plugin-zarf_0.3.0_darwin-arm64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.3.1/trivy-plugin-zarf_0.3.1_darwin-arm64.tar.gz
     bin: ./zarf
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.3.0/trivy-plugin-zarf_0.3.0_linux-amd64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.3.1/trivy-plugin-zarf_0.3.1_linux-amd64.tar.gz
     bin: ./zarf
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.3.0/trivy-plugin-zarf_0.3.0_linux-arm64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.3.1/trivy-plugin-zarf_0.3.1_linux-arm64.tar.gz
     bin: ./zarf
 requirements:
   - name: zarf


### PR DESCRIPTION
## Architecture Flag Support for OCI Packages

This PR adds support for specifying target architecture for pulling Zarf packages from OCI registries.

### Changes:
- Adds `--arch` / `-a` command-line flag to specify target architecture
- Passes the architecture flag to Zarf package pull command when specified
- Update README documentation to reflect new functionality

### How to use:
Pull a specific architecture from an OCI registry:
```bash
trivy zarf --arch amd64 oci://ghcr.io/zarf-dev/packages/package-name:tag
```

### Why this is needed:
This functionality is particularly important for local testing across different architectures. For example, this allows developers on arm64 machines to test amd64 packages (and vice versa) without having to manually download and extract packages for different architectures.

### Note:
- Default behavior is preserved - if no architecture is specified, the host architecture is used
- This change only affects OCI registry pulls, not local package scanning
