### PR TITLE
fix: returns proper exit code in case of underlying error

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -148,7 +148,7 @@ func scan(outputDir string, skipSignatureValidation bool, architecture string, d
 	// Scan each image in the OCI layout
 	errors := scanOCIImages(ociDir, outputDir, dbRepository)
 	if len(errors) != 0 {
-		logger.Default().Error("Error scanning images", "errors", errors)
+		return fmt.Errorf("error scanning images: %s", errorsToString(errors))
 	}
 	return nil
 }
@@ -251,7 +251,7 @@ func scanOCIImage(descriptor specv1.Descriptor, ociDir string, outputDir string,
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		// Return the error
-		return fmt.Errorf("Warning: Trivy scan failed for image %s: %v\n", imageName, err)
+		return fmt.Errorf("Trivy scan failed for image %s: %v\n", imageName, err)
 	}
 	return nil
 }
@@ -415,4 +415,17 @@ func sanitizeFilename(imageName string) string {
 	}
 
 	return sanitized
+}
+
+func errorsToString(errs []error) string {
+	var b strings.Builder
+	for i, err := range errs {
+		if err != nil {
+			b.WriteString(err.Error())
+			if i < len(errs)-1 {
+				b.WriteString("; ")
+			}
+		}
+	}
+	return b.String()
 }

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -9,22 +9,22 @@ platforms:
   - selector:
       os: darwin
       arch: amd64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.4.0/trivy-plugin-zarf_0.4.0_darwin-amd64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.4.1/trivy-plugin-zarf_0.4.1_darwin-amd64.tar.gz
     bin: ./zarf
   - selector:
       os: darwin
       arch: arm64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.4.0/trivy-plugin-zarf_0.4.0_darwin-arm64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.4.1/trivy-plugin-zarf_0.4.1_darwin-arm64.tar.gz
     bin: ./zarf
   - selector:
       os: linux
       arch: amd64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.4.0/trivy-plugin-zarf_0.4.0_linux-amd64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.4.1/trivy-plugin-zarf_0.4.1_linux-amd64.tar.gz
     bin: ./zarf
   - selector:
       os: linux
       arch: arm64
-    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.4.0/trivy-plugin-zarf_0.4.0_linux-arm64.tar.gz
+    uri: https://github.com/willswire/trivy-plugin-zarf/releases/download/v0.4.1/trivy-plugin-zarf_0.4.1_linux-arm64.tar.gz
     bin: ./zarf
 requirements:
   - name: zarf


### PR DESCRIPTION
If an error happened in the `trivy` call it wasn't bubbling up to the main program.